### PR TITLE
x11vnc: updated sx example in "Tips and Tricks"

### DIFF
--- a/xorg/x11vnc.txt
+++ b/xorg/x11vnc.txt
@@ -49,7 +49,7 @@ ________________________________________________________________________________
   |   "sx" example, configured per #/wiki/xorg/sx                              |
   +----------------------------------------------------------------------------+
   |                                                                            |
-  |   $ x11vnc -forever -display :1 -auth /home/USER/.sx/sx/xauthority         |
+  |   $ x11vnc -forever -display :1 -auth /home/USER/.config/sx/xauthority     |
   |                                                                            |
   +----------------------------------------------------------------------------+
   |   "startx" example, configured per #/wiki/xorg/startx                      |


### PR DESCRIPTION
`x11vnc -forever -display :1 -auth /home/USER/.sx/sx/xauthority` changed to `x11vnc -forever -display :1 -auth /home/USER/.config/sx/xauthority`