### PR TITLE
dev: remove lvm2 from mandatory dependency

### DIFF
--- a/dev/replacing-udev.txt
+++ b/dev/replacing-udev.txt
@@ -13,9 +13,6 @@ ________________________________________________________________________________
 - Xorg will be unable to automatically detect input devices.
 - Libinput will be unable to use its quirks system.
 
-- Some packages have an eudev dependency which cannot be removed.
-    - lvm2 (Compile _without_ --enable-udev_sync and --enable-udev_rules)
-
 
 BENEFITS
 ________________________________________________________________________________


### PR DESCRIPTION
Since https://github.com/kisslinux/community/commit/dd572263f9e7f0acb47c7cd6e1bd7eb662d93a45, LVM2 does not hard depend on eudev.