### PR TITLE
Using --label and not --create to set a label for efibootmgr

### DIFF
--- a/boot/efistub.txt
+++ b/boot/efistub.txt
@@ -46,9 +46,10 @@ the entry was added with 'efibootmgr --verbose'.
 +------------------------------------------------------------------------------+
 |                                                                              |
 |   $ efibootmgr \                                                             |
+|         --create \                                                           |
 |         --disk     /dev/sdX \                                                |
 |         --part     N \                                                       |
-|         --create   KISS \                                                    |
+|         --label    KISS \                                                    |
 |         --loader   /vmlinuz \                                                |
 |         --unicode  'root=/dev/sdYM' \                                        |
 |         --verbose                                                            |


### PR DESCRIPTION
I just spent 1 hour troobleshooting why the kernel would not want to mount root. Turns out --create doesn't take an argument and efibootmgr was truncating a portion of it into the bootargs, seemingly preventing the kernel to correctly parse other arguments.  
--label should be used to set the label instead.