### PR TITLE
Storage fixes

### DIFF
--- a/storage/disks.txt
+++ b/storage/disks.txt
@@ -402,7 +402,7 @@ filesystems for each partition.
     |              |                        |                                  |
     |  swap        | core/busybox           |  mkswap                          |
     |  EXT2/3/4    | extra/e2fsprogs        |  mkfs.ext2/3/4                   |
-    |  DOS/FATxx   | extra/dosfstools       |  mkfs.dos/fat/vat                |
+    |  DOS/FATxx   | extra/dosfstools       |  mkfs.dos/fat/vfat               |
     |  XFS         | extra/xfsprogs         |  mkfs.xfs                        |
     |  BTRFS       | community/btrfs-progs  |  mkfs.btrfs                      |
     |  NTFS        | community/ntfs-3g      |  mkfs.ntfs                       |
@@ -430,13 +430,13 @@ filesystems for each partition.
  
     +--------------------------------------------------------------------------+
     |                                                                          |
-    |   $ mkfs.ext4     /dev/sda2                                              |
-    |   $ mkfs.ext4     /dev/sda3                                              |
-    |   $ mkfs.fat -F32 /dev/sda1                                              |
+    |   $ mkfs.ext4     /dev/nvme0n1p2                                         |
+    |   $ mkfs.ext4     /dev/nvme0n1p3                                         |
+    |   $ mkfs.fat -F32 /dev/nvme0n1p1                                         |
     |                                                                          |
-    |   $ mount /dev/sda2 /mnt                                                 |
-    |   $ mount /dev/sda3 /mnt/home                                            |
-    |   $ mount /dev/sda1 /mnt/boot                                            |
+    |   $ mount /dev/nvme0n1p2 /mnt                                            |
+    |   $ mount /dev/nvme0n1p3 /mnt/home                                       |
+    |   $ mount /dev/nvme0n1p1 /mnt/boot                                       |
     |                                                                          |
     +--------------------------------------------------------------------------+
 

--- a/storage/zram.txt
+++ b/storage/zram.txt
@@ -18,6 +18,9 @@ enable and configure. First, ensure zram is enabled in the kernel:
 
 +------------------------------------------------------------------------------+
 |                                                                              |
+|   General setup --->                                                         |
+|       <*> Support for paging of anonymous memory (swap)                      |
+|                                                                              |
 |   Memory Management options --->                                             |
 |       <*> Memory allocator for compressed pages                              |
 |                                                                              |
@@ -52,7 +55,9 @@ $SIZE below can be given in bytes or suffixed by M,G.
 +------------------------------------------------------------------------------+
 |   #!/bin/sh -e                                                               |
 |                                                                              |
-|   modprobe zram                                                              |
+|   # Create four zram devices for swap, one for tmpfs                         |
+|                                                                              |
+|   modprobe zram num_devices=5                                                |
 |                                                                              |
 |   # create zram devices of $SIZE 2G                                          |
 |   # Mark the devices as swap devices                                         |
@@ -63,6 +68,14 @@ $SIZE below can be given in bytes or suffixed by M,G.
 |       mkswap "/dev/zram$dev"                                                 |
 |       swapon "/dev/zram$dev" -p 10                                           |
 |   done                                                                       |
+|                                                                              |
+|   # Create a 4G ext4 zram device to use as tmpfs                             |
+|                                                                              |
+|   echo 4G > /sys/block/zram4/disksize                                        |
+|   mkfs.ext4 /dev/zram4                                                       |
+|   mount /dev/zram4 /tmp                                                      |
+|   # /tmp requires sticky bit permissions for nonroot user access             |
+|   chmod 1777 /tmp                                                            |
 |                                                                              |
 +------------------------------------------------------------------------------+
 
@@ -77,6 +90,10 @@ $SIZE below can be given in bytes or suffixed by M,G.
 |       swapoff "/dev/zram$dev"                                                |
 |       echo 1 > "/sys/block/zram$dev/reset"                                   |
 |   done                                                                       |
+|                                                                              |
+|   # Unmount /tmp, reset zram device                                          |
+|   umount /dev/zram4                                                          |
+|   echo 1 > /sys/block/zram4/reset                                            |
 |                                                                              |
 +------------------------------------------------------------------------------+
 

--- a/storage/zram.txt
+++ b/storage/zram.txt
@@ -35,6 +35,9 @@ enable and configure. First, ensure zram is enabled in the kernel:
 |                                                                              |
 +------------------------------------------------------------------------------+
 
+lz4 is available in community. The default compression algorithm is lzo and is
+forced when CONFIG_ZRAM=y.
+
 Building compressed RAM block devices as a module is recommended because it
 enables runtime block device creation. If it is built-in to the kernel, pass
 zram.num_devices=X in the kernel commandline (bootloader or built-in).
@@ -48,6 +51,9 @@ method using an /etc/rc.d/zram.{boot,pre.shutdown} script is shown below.
 Because multiple ramdisks are allowed, it might be preferable to create 
 multiple zram devices for better utilization on multicore systems. 
 
+The compression used on zram block devices cannot be changed once the device is
+initialized, You cannot swap compression algorithms at run-time, unlink zswap.
+
 $SIZE below can be given in bytes or suffixed by M,G.
 
 +------------------------------------------------------------------------------+
@@ -60,20 +66,24 @@ $SIZE below can be given in bytes or suffixed by M,G.
 |   modprobe zram num_devices=5                                                |
 |                                                                              |
 |   # create zram devices of $SIZE 2G                                          |
+|   # Use lz4 compression on the devices                                       |
 |   # Mark the devices as swap devices                                         |
 |   # Enable the swap devices                                                  |
 |                                                                              |
 |   for dev in 0 1 2 3; do                                                     |
-|       echo 2G > "/sys/block/zram$dev/disksize"                               |
-|       mkswap "/dev/zram$dev"                                                 |
-|       swapon "/dev/zram$dev" -p 10                                           |
+|       echo lz4 > "/sys/block/zram$dev/comp_algorithm"                        |
+|       echo 2G >  "/sys/block/zram$dev/disksize"                              |
+|       mkswap     "/dev/zram$dev"                                             |
+|       swapon     "/dev/zram$dev" -p 10                                       |
 |   done                                                                       |
 |                                                                              |
-|   # Create a 4G ext4 zram device to use as tmpfs                             |
+|   # Create a 4G ext4 zram device to use as tmpfs with lz4 compression        |
 |                                                                              |
-|   echo 4G > /sys/block/zram4/disksize                                        |
-|   mkfs.ext4 /dev/zram4                                                       |
-|   mount /dev/zram4 /tmp                                                      |
+|   echo lz4  > /sys/block/zram4/comp_algorithm                                |
+|   echo 4G   > /sys/block/zram4/disksize                                      |
+|   mkfs.ext4   /dev/zram4                                                     |
+|   mount       /dev/zram4 /tmp                                                |
+|                                                                              |
 |   # /tmp requires sticky bit permissions for nonroot user access             |
 |   chmod 1777 /tmp                                                            |
 |                                                                              |

--- a/storage/zram.txt
+++ b/storage/zram.txt
@@ -52,7 +52,8 @@ Because multiple ramdisks are allowed, it might be preferable to create
 multiple zram devices for better utilization on multicore systems. 
 
 The compression used on zram block devices cannot be changed once the device is
-initialized, You cannot swap compression algorithms at run-time, unlink zswap.
+initialized. This means that you cannot swap compression algorithms at run-time,
+unlike with zswap.
 
 $SIZE below can be given in bytes or suffixed by M,G.
 

--- a/storage/zram.txt
+++ b/storage/zram.txt
@@ -35,8 +35,8 @@ enable and configure. First, ensure zram is enabled in the kernel:
 |                                                                              |
 +------------------------------------------------------------------------------+
 
-lz4 is available in community. The default compression algorithm is lzo and is
-forced when CONFIG_ZRAM=y.
+lz4 is available in community. The default compression algorithm is lzo and
+CONFIG_CRYPTO_LZO=y/m is forced when CONFIG_ZRAM=y/m.
 
 Building compressed RAM block devices as a module is recommended because it
 enables runtime block device creation. If it is built-in to the kernel, pass

--- a/storage/zswap.txt
+++ b/storage/zswap.txt
@@ -56,7 +56,7 @@ compressor is in use. To see them all,
 For information on setting up a swapfile or swap partition, see @/storage/disks.
 
 
-zbud versus z3fold versus zmalloc
+zbud versus z3fold versus zsmalloc
 ________________________________________________________________________________
 
 There are three different allocators to choose from for compressed pages:


### PR DESCRIPTION
Some small adjustments I noticed post-merge :(

Storage:

 just some typos (referencing /dev/sda when it should be /dev/nvme0n1 for instance)

zswap::

zmalloc -> zsmalloc

zram:

zram.boot changes; need to declare devices at load time, need to choose compression algorithm before initialization, added tmpfs example. 


These are things I should've noticed before the merge; sorry!